### PR TITLE
Add coding standard for PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,13 @@ allow for early capture of potential issues, but also as a method of spreading
 knowledge through the team.  This document contains the what, why and how of
 requesting and performing code reviews.
 
-
 ## Language-Specific Coding Standards
 
 * [ColdFusion](languages/coldfusion.md)
 * [CSS](languages/css.md)
 * [JavaScript](languages/javascript.md)
+* [PHP](languages/php.md)
 * [Ruby](languages/ruby.md)
-
 
 ## Contributing
 

--- a/languages/php.md
+++ b/languages/php.md
@@ -1,0 +1,8 @@
+# PHP
+
+## Style Guide
+
+The PHP language has a strong community, and we aim to ensure our code style
+lines up with generally-agreed best practices. As such, any PHP work should
+follow the community-driven style guide available at
+http://www.php-fig.org/psr/psr-2/.


### PR DESCRIPTION
We [recently discussed](https://globaldev.slack.com/archives/C4DA6225Q/p1489657025421681) adopting a coding standard for PHP like we have for other languages. I suggested that, rather than writing our own, it would be better to use an existing standard and suggested [PSR-2](http://www.php-fig.org/psr/psr-2/) which is widely used within the PHP community. This change adds the PSR-2 standard to our existing standards.