### PR TITLE
Update coding standards for built-in function attribute values

### DIFF
--- a/languages/coldfusion.md
+++ b/languages/coldfusion.md
@@ -62,7 +62,7 @@
 
 #### Boolean Values
 
-- Boolean values should be uppercase: `TRUE` and `FALSE`
+- Boolean values should be uppercase: `TRUE` and `FALSE`, except for built-in functions which should be lowercase for `output` and `required` attributes.
 - Use `TRUE` or `FALSE` for booleans, not `YES`, `NO`, `1` or `0`
 - Use boolean expressions for positive conditions where the explicit notation
   is not necessary


### PR DESCRIPTION
The settings for boolean attributes within built-in functions should be lowercase `true` and `false`. e.g.`output` and `required` attributes.
As discussed in Slack -  https://globaldev.slack.com/archives/C025JF6KP/p1431339965000139 and https://github.com/globaldev/wld/pull/9282