### PR TITLE
Update coding standards for boolean attributes in functions

### DIFF
--- a/languages/coldfusion.md
+++ b/languages/coldfusion.md
@@ -62,7 +62,9 @@
 
 #### Boolean Values
 
-- Boolean values should be uppercase: `TRUE` and `FALSE`, except for settings with boolean attributes which should be lowercase `true` and `false`. e.g.`output` and `required` attributes.
+- Boolean values should be uppercase: `TRUE` and `FALSE`, except for settings
+  with boolean attributes which should be lowercase `true` and `false`.
+  e.g.`output` and `required` attributes.
 - Use `TRUE` or `FALSE` for booleans, not `YES`, `NO`, `1` or `0`
 - Use boolean expressions for positive conditions where the explicit notation
   is not necessary

--- a/languages/coldfusion.md
+++ b/languages/coldfusion.md
@@ -62,7 +62,7 @@
 
 #### Boolean Values
 
-- Boolean values should be uppercase: `TRUE` and `FALSE`
+- Boolean values should be uppercase: `TRUE` and `FALSE`, except for settings with boolean attributes which should be lowercase `true` and `false`. e.g.`output` and `required` attributes.
 - Use `TRUE` or `FALSE` for booleans, not `YES`, `NO`, `1` or `0`
 - Use boolean expressions for positive conditions where the explicit notation
   is not necessary


### PR DESCRIPTION
The settings for boolean attributes within built-in functions should be lowercase `true` and `false`. e.g.`output` and `required` attributes.

As discussed in Slack -  https://globaldev.slack.com/archives/C025JF6KP/p1431339965000139 and https://github.com/globaldev/wld/pull/9282